### PR TITLE
add reset to original position method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -306,8 +306,8 @@ export default class Gestures extends Component {
   }
 
   reset() {
-    const left = 0
-    const top = 0
+    const left = 0;
+    const top = 0;
     this.dragStyles = { left, top };
     this.updateStyles();
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -305,6 +305,13 @@ export default class Gestures extends Component {
     this.view.setNativeProps({ styles });
   }
 
+  reset() {
+    const left = 0
+    const top = 0
+    this.dragStyles = { left, top };
+    this.updateStyles();
+  }
+
   render() {
     const { styles } = this.state;
 


### PR DESCRIPTION
Hi,

I do research for my project something like joystick / nipplejs on react native and your library shows up. but there is no reset to original position method. so i tweak a little bit.

there is how to use reset
```
<View style={{width: 100, height: 100, borderRadius: 125, backgroundColor: 'lightsalmon', justifyContent: 'center', alignItems: 'center'}}>
  <Gestures
    ref={ref => this.gestures = ref}
    onEnd={(event, styles) => {
      console.log(styles)
      this.gestures.reset()
    }}>
    <View style={{width: 30, height: 30, borderRadius: 20, backgroundColor: 'coral'}}/>
  </Gestures>
</View>
```
![nipple](https://user-images.githubusercontent.com/25797860/45915475-823d9c80-be7f-11e8-8877-55de7c77c92a.gif)



Thanks.