### PR TITLE
Using a dedicated <View> for the PanResponder

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -326,17 +326,24 @@ export default class Gestures extends Component {
 
   render() {
     const { style } = this.state;
-    const { children } = this.props;
+    const {
+      style: containerStyle,
+      children,
+    } = this.props;
 
     return (
       <View
-        ref={(c) => { this.view = c; }}
-        style={style}
+        style={containerStyle}
         {...this.pan.panHandlers}
       >
-        {
-          children
-        }
+        <View
+          ref={(c) => { this.view = c; }}
+          style={style}
+        >
+          {
+            children
+          }
+        </View>
       </View>
     );
   }


### PR DESCRIPTION
Hey [keske](https://github.com/keske), thanks for this excellent repo!

I encountered a minor issue on Android which prevented a thumbnail-sized child `<View>` from being interacted with after undergoing a number transformations. I believe this has something to do with how React decides `pointerEvent`s should be delegated, dependent upon a `<View>`'s resulting transform.

All I do in the PR below is delegate the `PanResponder` to a parent layout so that touch information propagates normally, irrespective of the child rotation. This seems to workaround the odd behaviour I was seeing.

Thanks again!