### PR TITLE
Move componentWillMount code to constructor.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import R from 'ramda';
-
 import { PanResponder, View } from 'react-native';
 
 // Utils
@@ -103,9 +101,7 @@ export default class Gestures extends Component {
         ...this.props.style,
       },
     };
-  }
 
-  componentWillMount() {
     this.pan = PanResponder.create({
       onPanResponderGrant: this.onMoveStart,
       onPanResponderMove: this.onMove,
@@ -131,7 +127,7 @@ export default class Gestures extends Component {
     const { initialStyles } = this;
     const { draggable } = this.props;
 
-    const isObject = R.is(Object, draggable);
+    const isObject = draggable === Object(draggable);
 
     const left = (isObject ? draggable.x : draggable)
       ? initialStyles.left + gestureState.dx
@@ -179,7 +175,7 @@ export default class Gestures extends Component {
     const { isScalingNow, style } = this.state;
     const { initialTouches } = this;
 
-    const isObject = R.is(Object, scalable);
+    const isObject = scalable === Object(scalable);
 
     if (isObject || scalable) {
       const currentDistance = distance(getTouches(event));

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "react-test-renderer": "16.6.3"
   },
   "dependencies": {
-    "prop-types": "^15.6.0",
-    "ramda": "^0.26.0"
+    "prop-types": "^15.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4343,10 +4343,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-ramda@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.0.tgz#3cbe059f5c18fbc0eb86f2396ab1f8320705424c"
-
 random-bytes@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"


### PR DESCRIPTION
- no more `componentWillMount is unsafe` warning.
- Ramda lib is no more necessary.